### PR TITLE
Added support for multi-partner config

### DIFF
--- a/scripts/getaccounts.js
+++ b/scripts/getaccounts.js
@@ -3,6 +3,7 @@ var api = require('../lib/api.js');
 var json2csv = require('json2csv');
 var fs = require('fs');
 
+
 // Get all the accounts and apikeys for a partner account, output as CSV
 
 // Servers qs:
@@ -12,8 +13,8 @@ var fs = require('fs');
 
 
 
-function outputFile(outputdata){
-    var fname= configId + '_accounts.csv';
+function outputFile(configId,outputdata){
+    var fname= configId+ '_accounts.csv';
     console.log("Outputing file... "+fname);
 //    console.log(JSON.stringify(outputdata)); 
     var input= {
@@ -32,7 +33,7 @@ function outputFile(outputdata){
     });
 }
     
-function acctFormat(accountInfo,cb) {
+function acctFormat(configId,accountInfo,cb) {
     var nr_url = "https://rpm.newrelic.com/accounts/";
     console.log("Getting Admin Information...");
     for (acct in accountInfo){
@@ -43,18 +44,24 @@ function acctFormat(accountInfo,cb) {
         //console.log(accountInfo[acct].apm_url)
 
     }
-    cb(accountInfo);
+    cb(configId,accountInfo);
 }
 
-var configId = config.get('configArr')[0];
-var partnerId= config.get(configId).partnerId;
-console.log("Processing Config: "+configId +' PartnerID: '+partnerId);
-api.partner.list(partnerId, configId, function(error, response, body) {
-  if(response.statusCode == 200) {
-    acctFormat(body.accounts,outputFile);
-  }
-  else {
-    console.log('error: '+ response.statusCode);
-    console.log(body);
-  }
+var partners=(config.get('configArr'));
+partners.forEach(function (configId){
+
+    partnerName= configId;
+    var partnerId= config.get(configId).partnerId;
+    console.log("Processing Config: "+configId +' PartnerID: '+partnerId);
+    api.partner.list(partnerId, configId, function(error, response, body) {
+      if(response.statusCode == 200) {
+        acctFormat(configId,body.accounts,outputFile);
+      }
+      else {
+        console.log('error: '+ response.statusCode);
+        console.log(body);
+      }
+    });
+
 });
+


### PR DESCRIPTION
Added support to run getAccounts on Multi-Patner IDs in config.

```
{
  "configArr": [
    "PartnerName1", "PartnerName2"
  ],
  "PartnerName1": {
    "partnerId": "<PARTNER1_ID>",
    "restKey": "<PARNER1_RESTKEY>"
  },
  "PartnerName2": {
    "partnerId": "<PARTNER2_ID>",
    "restKey": "<PARNER2_RESTKEY>"
  }
}
```
